### PR TITLE
Add 'lazy' attribute to GalleryListItem.vue

### DIFF
--- a/src/modules/gallery/components/GalleryListItem.vue
+++ b/src/modules/gallery/components/GalleryListItem.vue
@@ -37,6 +37,7 @@ onMounted(() => {
       v-if="mediaSignedUrlCreated"
       :src="mediaSignedUrl"
       @click="navigateToUploadDetailPage"
+      lazy
       fit="cover"
       :ratio="1"
       class="w-full h-full"


### PR DESCRIPTION
The 'lazy' attribute has been added to the 'mediaSignedUrl' element in the GalleryListItem.vue file. This lazy-loading can help improve the performance of the Gallery Page by only loading the specific media content when it's in the viewport.