### PR TITLE
Disable scroll behavior in router

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -10,13 +10,13 @@ const router = createRouter({
         authRouter,
         galleryRouter
     ],
-    scrollBehavior(to, from, savedPosition) {
-        if (savedPosition) {
-            return savedPosition
-        } else {
-            return { left: 0, top: 0}
-        }
-    },
+    // scrollBehavior(to, from, savedPosition) {
+    //     if (savedPosition) {
+    //         return savedPosition
+    //     } else {
+    //         return { left: 0, top: 0}
+    //     }
+    // },
 })
 
 export default router


### PR DESCRIPTION
The scroll behavior functionality in the router file has been commented out. This change temporarily disables the function managing the website's scrolling behavior to either save a scroll position or default it to the top-left corner of the screen. This is likely in preparation for changes or debugging that might affect the scrolling behavior.