### PR TITLE
Update router behavior and package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "pinia": "^2.1.6",
         "pwa-asset-generator": "^6.3.1",
         "vue": "^3.3.4",
-        "vue-router": "^4.2.4",
+        "vue-router": "^4.2.5",
         "vuestic-ui": "^1.8.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "pinia": "^2.1.6",
     "pwa-asset-generator": "^6.3.1",
     "vue": "^3.3.4",
-    "vue-router": "^4.2.4",
+    "vue-router": "^4.2.5",
     "vuestic-ui": "^1.8.0"
   },
   "devDependencies": {

--- a/src/modules/gallery/GalleryRouter.ts
+++ b/src/modules/gallery/GalleryRouter.ts
@@ -1,4 +1,5 @@
 import type {RouteRecordRaw} from "vue-router";
+import GalleryListPage from "@/modules/gallery/pages/GalleryListPage.vue";
 
 export enum GalleryRouteName {
     ROOT = 'gallery',
@@ -16,7 +17,7 @@ const galleryRouter: RouteRecordRaw = {
             path: '',
             name: GalleryRouteName.LIST,
             alias: 'list',
-            component: () => import('@/modules/gallery/pages/GalleryListPage.vue')
+            component: GalleryListPage
         },
         {
             path: 'upload',

--- a/src/router.ts
+++ b/src/router.ts
@@ -11,11 +11,18 @@ const router = createRouter({
         galleryRouter
     ],
     scrollBehavior(to, from, savedPosition) {
+        if (to.hash) {
+            return {
+                el: to.hash,
+                behavior: 'smooth',
+            }
+        }
+
         if (savedPosition) {
             return savedPosition
-        } else {
-            return {top: 0}
         }
+
+        return {top: 0, left: 0}
     },
 })
 


### PR DESCRIPTION
Improved the scroll behavior in the router to include smooth scroll to hash and default scroll top position and left position. The import method for the gallery list component in GalleryRouter has also been modified to be more direct. Lastly, the version of vue-router was bumped from 4.2.4 to 4.2.5.