### PR TITLE
Downgrade vuestic-ui version from 1.8.7 to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8650,9 +8650,9 @@
       }
     },
     "node_modules/vuestic-ui": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/vuestic-ui/-/vuestic-ui-1.8.7.tgz",
-      "integrity": "sha512-rTcviYlTfQWca1AiCBXxCIL0nX/QAc7arzHr3JiJX+JDHLn8+chfgXUxB2fwKnwZnLk1B30wd//ySzfQ1uRe0g==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vuestic-ui/-/vuestic-ui-1.8.0.tgz",
+      "integrity": "sha512-nfYID3AIRjtIZH6FMb28cvB6mfkw3D/ZLqHHEfWQXcjOPoBinlnMvucL070wlQ2JI7DPusaGZrNbBScZDPzrUg==",
       "dependencies": {
         "@floating-ui/vue": "^1.0.1",
         "@types/lodash": "^4.14.161",


### PR DESCRIPTION
The package vuestic-ui associated with the project has been downgraded from version 1.8.7 to 1.8.0. This was done to resolve compatibility issues or take advantage of specific features or bug fixes in the older version.