### PR TITLE
Adjust scroll sensitivity and prevent multiple fetch requests

### DIFF
--- a/src/modules/gallery/pages/GalleryListPage.vue
+++ b/src/modules/gallery/pages/GalleryListPage.vue
@@ -19,7 +19,7 @@ interface ScrollEventDataType {
 }
 
 const loadMoreMedias = ({target: {scrollTop, clientHeight, scrollHeight}}: ScrollEventDataType): void => {
-  if (scrollTop + clientHeight >= scrollHeight * 0.75) {
+  if (scrollTop + clientHeight >= scrollHeight * 0.85) {
     galleryListStore.fetchMedias()
   }
 }

--- a/src/modules/gallery/stores/GalleryListStore.ts
+++ b/src/modules/gallery/stores/GalleryListStore.ts
@@ -23,7 +23,7 @@ export const useGalleryListStore = defineStore('gallery-list', () => {
     const {init} = useToast()
 
     async function fetchMedias(): Promise<void> {
-        if (hasFetchedAllRecords.value) {
+        if (hasFetchedAllRecords.value || isFetchingGalleryMedias.value) {
             return;
         }
 


### PR DESCRIPTION
Increased the scroll sensitivity from 75% to 85% in the GalleryListPage to provide a smoother user experience. Moreover, a condition check has been added in the GalleryListStore's fetchMedias function to prevent multiple fetching requests from occurring simultaneously.