### PR TITLE
feat: Add corsHeaders to Responder class

### DIFF
--- a/supabase/functions/_shared/responder.ts
+++ b/supabase/functions/_shared/responder.ts
@@ -11,8 +11,14 @@ interface ErrorResponseCommonStructure {
 }
 
 export class Responder {
+    private readonly corsHeaders: Record<string, string> = {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    }
+
     private readonly defaultResponseHeaders: Record<string, string> = {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...this.corsHeaders
     }
 
     private responseCommonStructure(status: number, success: boolean): ResponseCommonStructure {
@@ -63,10 +69,7 @@ export class Responder {
 
     responseCors(): Response {
         return new Response('ok', {
-            headers: {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
-            }
+            headers: this.corsHeaders
         })
     }
 }


### PR DESCRIPTION
corsHeaders have been added to the Responder class for improved code reuse and readability. This contains necessary headers for handling CORS (Cross-Origin Resource Sharing) related responses. The specific headers for CORS have been moved from the responseCors method to the corsHeaders.