### PR TITLE
feat: Add PWA update notification with service worker management

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,2 +1,3 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/vue" />
 declare module "*.vue";

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onUnmounted, ref } from "vue";
 import { AuthRouteName } from "@/modules/auth/AuthRouter";
 import { MasterRouteName } from "@/modules/master/MasterRouter";
 import { GalleryRouteName } from "@/modules/gallery/GalleryRouter";
@@ -17,9 +17,14 @@ import {
 import { WebpageBookmarkRouteName } from "@/modules/webpage-bookmark/WebpageBookmarkRouter";
 import { WEB_BOOKMARK_ROOT_DIR_ID } from "@/modules/webpage-bookmark/WebpageBookmarkEntities.ts";
 import AppTopBar from "@/modules/master/components/AppTopBar.vue";
+import PwaUpdateNotification from "@/modules/master/components/PwaUpdateNotification.vue";
+import { usePwaUpdateService } from "@/modules/master/MasterServiceContainer";
 
 const authenticationService = useAuthenticationService();
 authenticationService.registerOnAuthStateChange();
+
+const pwaUpdateService = usePwaUpdateService();
+pwaUpdateService.startWatching();
 
 const hideNavBar = computed((): boolean => {
   return router.currentRoute.value.name === AuthRouteName.LOGIN;
@@ -67,6 +72,10 @@ const navItems: NavItem[] = [
   },
   { label: "Profile", icon: "person", routeName: AuthRouteName.PROFILE },
 ];
+
+onUnmounted((): void => {
+  pwaUpdateService.stopWatching();
+});
 </script>
 
 <template>
@@ -77,6 +86,8 @@ const navItems: NavItem[] = [
       :visible="!hideNavBar"
       @toggle-sidebar="isSidebarOpen = !isSidebarOpen"
     />
+
+    <PwaUpdateNotification />
 
     <Transition name="sidebar-fade">
       <div

--- a/src/modules/master/MasterServiceContainer.ts
+++ b/src/modules/master/MasterServiceContainer.ts
@@ -1,6 +1,7 @@
 import { ToastService } from "@/modules/master/services/ToastService";
 import { ModalService } from "@/modules/master/services/ModalService";
 import { MasterNavigationService } from "@/modules/master/services/MasterNavigationService";
+import { PwaUpdateService } from "@/modules/master/services/PwaUpdateService";
 import router from "@/router";
 
 const useToastService = () => new ToastService();
@@ -9,4 +10,11 @@ const useModalService = () => new ModalService();
 
 const useMasterNavigationService = () => new MasterNavigationService(router);
 
-export { useToastService, useModalService, useMasterNavigationService };
+const usePwaUpdateService = () => new PwaUpdateService();
+
+export {
+  useToastService,
+  useModalService,
+  useMasterNavigationService,
+  usePwaUpdateService,
+};

--- a/src/modules/master/components/PwaUpdateNotification.vue
+++ b/src/modules/master/components/PwaUpdateNotification.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { VaButton, VaModal } from "vuestic-ui";
+
+import { usePwaUpdateStore } from "@/modules/master/stores/PwaUpdateStore";
+
+const pwaUpdateStore = usePwaUpdateStore();
+
+const handleUpdate = async (): Promise<void> => {
+  await pwaUpdateStore.updateServiceWorker?.();
+};
+</script>
+
+<template>
+  <va-modal
+    :model-value="pwaUpdateStore.needRefresh"
+    title="Update Available"
+    hide-default-actions
+    no-dismiss
+    no-outside-dismiss
+    no-esc-dismiss
+  >
+    <p>
+      A new version of the app is available. Please restart the app to apply the
+      update.
+    </p>
+
+    <div class="mt-4 flex justify-end">
+      <va-button color="primary" @click="handleUpdate">Restart App</va-button>
+    </div>
+  </va-modal>
+</template>

--- a/src/modules/master/services/PwaUpdateService.ts
+++ b/src/modules/master/services/PwaUpdateService.ts
@@ -1,0 +1,44 @@
+import { useRegisterSW } from "virtual:pwa-register/vue";
+import { watch } from "vue";
+
+import { usePwaUpdateStore } from "@/modules/master/stores/PwaUpdateStore";
+
+export class PwaUpdateService {
+  private readonly pwaUpdateStore = usePwaUpdateStore();
+  private stopNeedRefreshWatcher: (() => void) | null = null;
+  private stopOfflineReadyWatcher: (() => void) | null = null;
+
+  startWatching(): void {
+    this.stopWatching();
+
+    const { needRefresh, offlineReady, updateServiceWorker } = useRegisterSW({
+      immediate: true,
+    });
+
+    this.stopNeedRefreshWatcher = watch(
+      needRefresh,
+      (value): void => {
+        this.pwaUpdateStore.needRefresh = value;
+      },
+      { immediate: true },
+    );
+
+    this.stopOfflineReadyWatcher = watch(
+      offlineReady,
+      (value): void => {
+        this.pwaUpdateStore.offlineReady = value;
+      },
+      { immediate: true },
+    );
+
+    this.pwaUpdateStore.updateServiceWorker = updateServiceWorker;
+  }
+
+  stopWatching(): void {
+    this.stopNeedRefreshWatcher?.();
+    this.stopOfflineReadyWatcher?.();
+    this.stopNeedRefreshWatcher = null;
+    this.stopOfflineReadyWatcher = null;
+    this.pwaUpdateStore.updateServiceWorker = null;
+  }
+}

--- a/src/modules/master/stores/PwaUpdateStore.ts
+++ b/src/modules/master/stores/PwaUpdateStore.ts
@@ -1,0 +1,14 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+
+export const usePwaUpdateStore = defineStore("pwa-update", () => {
+  const needRefresh = ref(false);
+  const offlineReady = ref(false);
+  const updateServiceWorker = ref<(() => Promise<void>) | null>(null);
+
+  return {
+    needRefresh,
+    offlineReady,
+    updateServiceWorker,
+  };
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,12 +10,12 @@ export default defineConfig({
   plugins: [
     vue(),
     VitePWA({
-      registerType: "autoUpdate",
+      registerType: "prompt",
       devOptions: {
         enabled: false,
       },
       strategies: "generateSW",
-      injectRegister: "auto",
+      injectRegister: false,
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
       },


### PR DESCRIPTION
- Introduced `PwaUpdateNotification.vue` to display update prompts and handle user actions for app updates.
- Implemented `PwaUpdateService` and `PwaUpdateStore` to manage service worker updates and track state changes.
- Updated `App.vue` to integrate the PWA update notification component and lifecycle management.
- Modified Vite PWA configuration to use `prompt` for update notifications and disabled automatic registration.